### PR TITLE
Bug fixes on RsaKey class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ MANIFEST
 
 # Backup files
 *~
+*.bak

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -44,3 +44,4 @@ Fabrizio Tarizzo
 Kevin M. Turner
 Barry A. Warsaw
 Eric Young
+Hannes van Niekerk

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -12,6 +12,11 @@ New features
   `new` accepts `IV` as well as `iv` as parameter.
 * Dedicated tests for CBC and CFB, including NIST test vectors
 
+Resolved issues
+---------------
+
+* RSA key size returned correctly in RsaKey.__repr__ method.
+
 Breaks in compatibility
 -----------------------
 
@@ -122,7 +127,7 @@ Resolved issues
 Breaks in compatibility
 -----------------------
 
-* New dependency on ctypes with Python 2.4. 
+* New dependency on ctypes with Python 2.4.
 * The ``counter`` parameter of a CTR mode cipher must be generated via
   ``Crypto.Util.Counter``. It cannot be a generic callable anymore.
 * Removed the ``Crypto.Random.Fortuna`` package (due to lack of test vectors).

--- a/lib/Crypto/PublicKey/RSA.py
+++ b/lib/Crypto/PublicKey/RSA.py
@@ -69,6 +69,7 @@ __all__ = ['generate', 'construct', 'importKey', 'RSAImplementation',
 from Crypto.Util.py3compat import *
 
 import binascii
+import math
 import struct
 
 from Crypto import Random
@@ -134,7 +135,7 @@ class RsaKey(object):
         if not self.has_private():
             raise TypeError("This is not a private key")
 
-        e, d, n, p, q, u = [self._key[comp] for comp in 'e', 'd', 'n', 'p', 'q', 'u']
+        e, d, n, p, q, u = [self._key[comp] for comp in ('e', 'd', 'n', 'p', 'q', 'u')]
 
         # Blinded RSA decryption (to prevent timing attacks):
         # Step 1: Generate random secret blinding factor r, such that 0 < r < n-1
@@ -160,7 +161,7 @@ class RsaKey(object):
         return 'd' in self._key
 
     def publickey(self):
-        return RsaKey(dict([(k, self._key[k]) for k in 'n', 'e']))
+        return RsaKey(dict([(k, self._key[k]) for k in ('n', 'e')]))
 
     def __eq__(self, other):
         return self._key == other._key
@@ -177,8 +178,8 @@ class RsaKey(object):
         attrs = []
         for k in self._keydata:
             if k == 'n':
-                attrs.append("n(%d)" % (self.size()+1,))
-            elif hasattr(self.key, k):
+                attrs.append("n(%d)" % (int(math.log(self.n, 2))+1))
+            elif hasattr(self, k):
                 attrs.append(k)
         if self.has_private():
             attrs.append("private")
@@ -263,7 +264,7 @@ class RsaKey(object):
             randfunc = Random.get_random_bytes
 
         if format=='OpenSSH':
-               eb, nb = [self._key[comp].to_bytes() for comp in 'e', 'n']
+               eb, nb = [self._key[comp].to_bytes() for comp in ('e', 'n')]
                if bord(eb[0]) & 0x80: eb=bchr(0x00)+eb
                if bord(nb[0]) & 0x80: nb=bchr(0x00)+nb
                keyparts = [ b('ssh-rsa'), eb, nb ]


### PR DESCRIPTION
Remove reference to ".size()" in RsaKey.**repr** method and return key
size with alternative implementation.
Fix "hasattr" check in RsaKey.**repr** method.
Fix broken "in" expressions.
